### PR TITLE
Fixup eval add onset offset err bf

### DIFF
--- a/doc/notebooks/BFRepository-results/all-birds.ipynb
+++ b/doc/notebooks/BFRepository-results/all-birds.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +64,170 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_cols = [f'{name}_n_frame_err' for name in ('y_pred_np', 'y_pred_np_mindur', 'y_pred_np_mv', 'y_pred_np_mindur_mv')] "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>y_pred_np_n_frame_err</th>\n",
+       "      <th>y_pred_np_mindur_n_frame_err</th>\n",
+       "      <th>y_pred_np_mv_n_frame_err</th>\n",
+       "      <th>y_pred_np_mindur_mv_n_frame_err</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>213</td>\n",
+       "      <td>213</td>\n",
+       "      <td>213</td>\n",
+       "      <td>213</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>106</td>\n",
+       "      <td>106</td>\n",
+       "      <td>106</td>\n",
+       "      <td>106</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>136</td>\n",
+       "      <td>136</td>\n",
+       "      <td>136</td>\n",
+       "      <td>136</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>137</td>\n",
+       "      <td>137</td>\n",
+       "      <td>137</td>\n",
+       "      <td>137</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>92</td>\n",
+       "      <td>92</td>\n",
+       "      <td>92</td>\n",
+       "      <td>92</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>333</th>\n",
+       "      <td>500</td>\n",
+       "      <td>500</td>\n",
+       "      <td>500</td>\n",
+       "      <td>500</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>334</th>\n",
+       "      <td>495</td>\n",
+       "      <td>495</td>\n",
+       "      <td>495</td>\n",
+       "      <td>495</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>335</th>\n",
+       "      <td>709</td>\n",
+       "      <td>709</td>\n",
+       "      <td>709</td>\n",
+       "      <td>709</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>336</th>\n",
+       "      <td>517</td>\n",
+       "      <td>517</td>\n",
+       "      <td>517</td>\n",
+       "      <td>517</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>337</th>\n",
+       "      <td>1242</td>\n",
+       "      <td>1242</td>\n",
+       "      <td>1242</td>\n",
+       "      <td>1242</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>338 rows × 4 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     y_pred_np_n_frame_err  y_pred_np_mindur_n_frame_err  \\\n",
+       "0                      213                           213   \n",
+       "1                      106                           106   \n",
+       "2                      136                           136   \n",
+       "3                      137                           137   \n",
+       "4                       92                            92   \n",
+       "..                     ...                           ...   \n",
+       "333                    500                           500   \n",
+       "334                    495                           495   \n",
+       "335                    709                           709   \n",
+       "336                    517                           517   \n",
+       "337                   1242                          1242   \n",
+       "\n",
+       "     y_pred_np_mv_n_frame_err  y_pred_np_mindur_mv_n_frame_err  \n",
+       "0                         213                              213  \n",
+       "1                         106                              106  \n",
+       "2                         136                              136  \n",
+       "3                         137                              137  \n",
+       "4                          92                               92  \n",
+       "..                        ...                              ...  \n",
+       "333                       500                              500  \n",
+       "334                       495                              495  \n",
+       "335                       709                              709  \n",
+       "336                       517                              517  \n",
+       "337                      1242                             1242  \n",
+       "\n",
+       "[338 rows x 4 columns]"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df[n_cols]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,6 +244,10 @@
     "    'segment_error_rate_majority_vote',\n",
     "    'segment_error_rate_min_dur_maj_vote',\n",
     "    'segment_error_rate_min_segment_dur',\n",
+    "    'y_pred_np_boundary_err', \n",
+    "    'y_pred_np_mindur_boundary_err', \n",
+    "    'y_pred_np_mv_boundary_err', \n",
+    "    'y_pred_np_mindur_mv_boundary_err',\n",
     "]\n",
     "\n",
     "records = defaultdict(list)\n",
@@ -89,6 +256,8 @@
     "    bird_id = csv.name.split('.')[0]\n",
     "\n",
     "    df = pd.read_csv(csv)\n",
+    "    for y_pred_name in ('y_pred_np', 'y_pred_np_mindur', 'y_pred_np_mv', 'y_pred_np_mindur_mv'):\n",
+    "        df[f'{y_pred_name}_boundary_err'] = df[f'{y_pred_name}_n_unlabeled_err_within_2_timebin_onoffset'] / df[f'{y_pred_name}_n_frame_err']\n",
     "    for count, date in enumerate(df['date'].unique()):\n",
     "        day = count + 1\n",
     "        records['date'].append(date)\n",
@@ -112,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,6 +321,30 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mean duration (seconds) of test set: 1527.972117647059\n",
+      "std. dev of test set duration  (seconds) : 888.5988765065682\n",
+      "mean duration (minutes) of test set: 25.466201960784314\n",
+      "std. dev of test set duration (minutes): 14.80998127510947\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('mean duration (seconds) of test set:', data['test_set_duration'].mean())\n",
+    "print('std. dev of test set duration  (seconds) :', data['test_set_duration'].std())\n",
+    "\n",
+    "print('mean duration (minutes) of test set:', data['test_set_duration_min'].mean())\n",
+    "print('std. dev of test set duration (minutes):', data['test_set_duration_min'].std())"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -161,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -178,10 +371,14 @@
        " 'segment_error_rate',\n",
        " 'segment_error_rate_majority_vote',\n",
        " 'segment_error_rate_min_dur_maj_vote',\n",
-       " 'segment_error_rate_min_segment_dur']"
+       " 'segment_error_rate_min_segment_dur',\n",
+       " 'y_pred_np_boundary_err',\n",
+       " 'y_pred_np_mindur_boundary_err',\n",
+       " 'y_pred_np_mv_boundary_err',\n",
+       " 'y_pred_np_mindur_mv_boundary_err']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -246,10 +443,10 @@
        "      <th>mean_levenshtein_majority_vote</th>\n",
        "      <th>mean_levenshtein_min_dur_maj_vote</th>\n",
        "      <th>...</th>\n",
-       "      <th>mean_segment_error_rate</th>\n",
-       "      <th>mean_segment_error_rate_majority_vote</th>\n",
-       "      <th>mean_segment_error_rate_min_dur_maj_vote</th>\n",
-       "      <th>mean_segment_error_rate_min_segment_dur</th>\n",
+       "      <th>mean_y_pred_np_boundary_err</th>\n",
+       "      <th>mean_y_pred_np_mindur_boundary_err</th>\n",
+       "      <th>mean_y_pred_np_mindur_mv_boundary_err</th>\n",
+       "      <th>mean_y_pred_np_mv_boundary_err</th>\n",
        "      <th>test_set_duration</th>\n",
        "      <th>test_set_duration_min</th>\n",
        "      <th>mean_err</th>\n",
@@ -272,10 +469,10 @@
        "      <td>2.476923</td>\n",
        "      <td>1.138462</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.110552</td>\n",
-       "      <td>0.037118</td>\n",
-       "      <td>0.017398</td>\n",
-       "      <td>0.017398</td>\n",
+       "      <td>0.793073</td>\n",
+       "      <td>0.793073</td>\n",
+       "      <td>0.793073</td>\n",
+       "      <td>0.793073</td>\n",
        "      <td>977.982</td>\n",
        "      <td>16.299700</td>\n",
        "      <td>0.024880</td>\n",
@@ -296,10 +493,10 @@
        "      <td>1.950000</td>\n",
        "      <td>0.800000</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.100051</td>\n",
-       "      <td>0.027342</td>\n",
-       "      <td>0.015219</td>\n",
-       "      <td>0.015219</td>\n",
+       "      <td>0.771463</td>\n",
+       "      <td>0.771463</td>\n",
+       "      <td>0.771463</td>\n",
+       "      <td>0.771463</td>\n",
        "      <td>759.644</td>\n",
        "      <td>12.660733</td>\n",
        "      <td>0.023851</td>\n",
@@ -320,10 +517,10 @@
        "      <td>2.052632</td>\n",
        "      <td>0.842105</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.105894</td>\n",
-       "      <td>0.031186</td>\n",
-       "      <td>0.012146</td>\n",
-       "      <td>0.012146</td>\n",
+       "      <td>0.802483</td>\n",
+       "      <td>0.802483</td>\n",
+       "      <td>0.802483</td>\n",
+       "      <td>0.802483</td>\n",
        "      <td>1360.548</td>\n",
        "      <td>22.675800</td>\n",
        "      <td>0.020973</td>\n",
@@ -344,10 +541,10 @@
        "      <td>1.962025</td>\n",
        "      <td>0.822785</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.106126</td>\n",
-       "      <td>0.029741</td>\n",
-       "      <td>0.012542</td>\n",
-       "      <td>0.012542</td>\n",
+       "      <td>0.788175</td>\n",
+       "      <td>0.788175</td>\n",
+       "      <td>0.788175</td>\n",
+       "      <td>0.788175</td>\n",
        "      <td>1044.610</td>\n",
        "      <td>17.410167</td>\n",
        "      <td>0.023314</td>\n",
@@ -368,10 +565,10 @@
        "      <td>8.948718</td>\n",
        "      <td>6.717949</td>\n",
        "      <td>...</td>\n",
-       "      <td>0.315383</td>\n",
-       "      <td>0.138630</td>\n",
-       "      <td>0.091870</td>\n",
-       "      <td>0.091870</td>\n",
+       "      <td>0.482765</td>\n",
+       "      <td>0.482765</td>\n",
+       "      <td>0.482765</td>\n",
+       "      <td>0.482765</td>\n",
        "      <td>500.218</td>\n",
        "      <td>8.336967</td>\n",
        "      <td>0.079965</td>\n",
@@ -381,7 +578,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>5 rows × 21 columns</p>\n",
+       "<p>5 rows × 25 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
@@ -406,51 +603,219 @@
        "15                        1.962025                           0.822785  ...   \n",
        "16                        8.948718                           6.717949  ...   \n",
        "\n",
-       "    mean_segment_error_rate  mean_segment_error_rate_majority_vote  \\\n",
-       "12                 0.110552                               0.037118   \n",
-       "13                 0.100051                               0.027342   \n",
-       "14                 0.105894                               0.031186   \n",
-       "15                 0.106126                               0.029741   \n",
-       "16                 0.315383                               0.138630   \n",
+       "    mean_y_pred_np_boundary_err  mean_y_pred_np_mindur_boundary_err  \\\n",
+       "12                     0.793073                            0.793073   \n",
+       "13                     0.771463                            0.771463   \n",
+       "14                     0.802483                            0.802483   \n",
+       "15                     0.788175                            0.788175   \n",
+       "16                     0.482765                            0.482765   \n",
        "\n",
-       "    mean_segment_error_rate_min_dur_maj_vote  \\\n",
-       "12                                  0.017398   \n",
-       "13                                  0.015219   \n",
-       "14                                  0.012146   \n",
-       "15                                  0.012542   \n",
-       "16                                  0.091870   \n",
+       "    mean_y_pred_np_mindur_mv_boundary_err  mean_y_pred_np_mv_boundary_err  \\\n",
+       "12                               0.793073                        0.793073   \n",
+       "13                               0.771463                        0.771463   \n",
+       "14                               0.802483                        0.802483   \n",
+       "15                               0.788175                        0.788175   \n",
+       "16                               0.482765                        0.482765   \n",
        "\n",
-       "    mean_segment_error_rate_min_segment_dur  test_set_duration  \\\n",
-       "12                                 0.017398            977.982   \n",
-       "13                                 0.015219            759.644   \n",
-       "14                                 0.012146           1360.548   \n",
-       "15                                 0.012542           1044.610   \n",
-       "16                                 0.091870            500.218   \n",
+       "    test_set_duration  test_set_duration_min  mean_err  \\\n",
+       "12            977.982              16.299700  0.024880   \n",
+       "13            759.644              12.660733  0.023851   \n",
+       "14           1360.548              22.675800  0.020973   \n",
+       "15           1044.610              17.410167  0.023314   \n",
+       "16            500.218               8.336967  0.079965   \n",
        "\n",
-       "    test_set_duration_min  mean_err  mean_err_majority_vote  \\\n",
-       "12              16.299700  0.024880                0.023545   \n",
-       "13              12.660733  0.023851                0.022417   \n",
-       "14              22.675800  0.020973                0.019630   \n",
-       "15              17.410167  0.023314                0.021570   \n",
-       "16               8.336967  0.079965                0.075220   \n",
+       "    mean_err_majority_vote  mean_err_min_dur_maj_vote  \\\n",
+       "12                0.023545                   0.023176   \n",
+       "13                0.022417                   0.022193   \n",
+       "14                0.019630                   0.019303   \n",
+       "15                0.021570                   0.021284   \n",
+       "16                0.075220                   0.077171   \n",
        "\n",
-       "    mean_err_min_dur_maj_vote  mean_err_min_segment_dur  \n",
-       "12                   0.023176                  0.023176  \n",
-       "13                   0.022193                  0.022193  \n",
-       "14                   0.019303                  0.019303  \n",
-       "15                   0.021284                  0.021284  \n",
-       "16                   0.077171                  0.077171  \n",
+       "    mean_err_min_segment_dur  \n",
+       "12                  0.023176  \n",
+       "13                  0.022193  \n",
+       "14                  0.019303  \n",
+       "15                  0.021284  \n",
+       "16                  0.077171  \n",
        "\n",
-       "[5 rows x 21 columns]"
+       "[5 rows x 25 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "data[data['bird_id'] == 'or60yw70']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['bird_id', 'date', 'day', 'mean_acc', 'mean_acc_majority_vote',\n",
+       "       'mean_acc_min_dur_maj_vote', 'mean_acc_min_segment_dur',\n",
+       "       'mean_levenshtein', 'mean_levenshtein_majority_vote',\n",
+       "       'mean_levenshtein_min_dur_maj_vote', 'mean_levenshtein_min_segment_dur',\n",
+       "       'mean_segment_error_rate', 'mean_segment_error_rate_majority_vote',\n",
+       "       'mean_segment_error_rate_min_dur_maj_vote',\n",
+       "       'mean_segment_error_rate_min_segment_dur',\n",
+       "       'mean_y_pred_np_boundary_err', 'mean_y_pred_np_mindur_boundary_err',\n",
+       "       'mean_y_pred_np_mindur_mv_boundary_err',\n",
+       "       'mean_y_pred_np_mv_boundary_err', 'test_set_duration',\n",
+       "       'test_set_duration_min', 'mean_err', 'mean_err_majority_vote',\n",
+       "       'mean_err_min_dur_maj_vote', 'mean_err_min_segment_dur'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.029\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_err'].mean():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.014\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_err'].std():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.173\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_segment_error_rate'].mean():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.086\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_segment_error_rate'].std():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.064\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_segment_error_rate_majority_vote'].mean():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.037\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_segment_error_rate_majority_vote'].std():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.649\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_y_pred_np_mv_boundary_err'].mean():.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.143\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{data['mean_y_pred_np_mv_boundary_err'].std():.3f}\")"
    ]
   },
   {

--- a/src/scripts/BFSongRepository/eval_without_and_with_output_transforms.py
+++ b/src/scripts/BFSongRepository/eval_without_and_with_output_transforms.py
@@ -10,7 +10,8 @@ from tqdm import tqdm
 
 import vak.device
 import vak.files
-import vak.labeled_timebins as lbl_tb_funcs
+from vak.labeled_timebins import lbl_tb2segments, majority_vote_transform, lbl_tb_segment_inds_list, \
+    remove_short_segments
 from vak import config, io, models, transforms
 from vak.datasets.vocal_dataset import VocalDataset
 
@@ -51,6 +52,7 @@ def compute_metrics(metrics, y_true, y_pred, y_true_labels, y_pred_labels):
 
 def metrics_df_from_toml_path(toml_path,
                               min_segment_dur,
+                              n_timebin_from_onoffset,
                               device='cuda',
                               spect_key='s',
                               timebins_key='t'):
@@ -60,11 +62,22 @@ def metrics_df_from_toml_path(toml_path,
 
     Parameters
     ----------
-    toml_path
-    min_segment_dur
-    device
-    spect_key
-    timebins_key
+    toml_path : str, pathlib.Path
+        to config .toml file
+    min_segment_dur : float
+        minimum duration of a segment, in seconds.
+    n_timebin_from_onoffset : int
+        number of timebins from onset or offset in which
+        to count
+    device : str
+        device on which ``torch`` should place network.
+        Default is 'cuda'
+    spect_key : str
+        key used to access spectrogram in files of arrays.
+        Default is 's'
+    timebins_key : str
+        key used to access vector of timebins in files of arrays.
+        Default is 't'
 
     Returns
     -------
@@ -167,9 +180,9 @@ def metrics_df_from_toml_path(toml_path,
             records['spect_path'].append(spect_path)  # remove str from tuple
             y_true = y_true.to(device)
             y_true_np = np.squeeze(y_true.cpu().numpy())
-            y_true_labels, _, _ = lbl_tb_funcs.lbl_tb2segments(y_true_np,
-                                                               labelmap=labelmap,
-                                                               t=t)
+            y_true_labels, onsets_s, offsets_s = lbl_tb2segments(y_true_np,
+                                                                 labelmap=labelmap,
+                                                                 t=t)
             y_true_labels = ''.join(y_true_labels.tolist())
 
             y_pred = pred_dict[spect_path]
@@ -177,11 +190,11 @@ def metrics_df_from_toml_path(toml_path,
             y_pred = torch.flatten(y_pred)
             y_pred = y_pred.unsqueeze(0)[padding_mask]
             y_pred_np = np.squeeze(y_pred.cpu().numpy())
-            y_pred_labels, _, _ = lbl_tb_funcs.lbl_tb2segments(y_pred_np,
-                                                               labelmap=labelmap,
-                                                               t=t,
-                                                               min_segment_dur=None,
-                                                               majority_vote=False)
+            y_pred_labels, _, _ = lbl_tb2segments(y_pred_np,
+                                                  labelmap=labelmap,
+                                                  t=t,
+                                                  min_segment_dur=None,
+                                                  majority_vote=False)
             y_pred_labels = ''.join(y_pred_labels.tolist())
 
             metric_vals_batch = compute_metrics(metrics, y_true, y_pred, y_true_labels, y_pred_labels)
@@ -190,17 +203,17 @@ def metrics_df_from_toml_path(toml_path,
 
             # --- apply majority vote and min segment dur transforms separately
             # need segment_inds_list for both transforms
-            segment_inds_list = lbl_tb_funcs.lbl_tb_segment_inds_list(y_pred_np,
-                                                                      unlabeled_label=labelmap['unlabeled'])
+            segment_inds_list = lbl_tb_segment_inds_list(y_pred_np,
+                                                         unlabeled_label=labelmap['unlabeled'])
 
             # ---- majority vote transform
-            y_pred_np_mv = lbl_tb_funcs.majority_vote_transform(y_pred_np, segment_inds_list)
+            y_pred_np_mv = majority_vote_transform(y_pred_np, segment_inds_list)
             y_pred_mv = to_long_tensor(y_pred_np_mv).to(device)
-            y_pred_mv_labels, _, _ = lbl_tb_funcs.lbl_tb2segments(y_pred_np_mv,
-                                                                  labelmap=labelmap,
-                                                                  t=t,
-                                                                  min_segment_dur=None,
-                                                                  majority_vote=False)
+            y_pred_mv_labels, _, _ = lbl_tb2segments(y_pred_np_mv,
+                                                     labelmap=labelmap,
+                                                     t=t,
+                                                     min_segment_dur=None,
+                                                     majority_vote=False)
             y_pred_mv_labels = ''.join(y_pred_mv_labels.tolist())
             metric_vals_batch_mv = compute_metrics(metrics, y_true, y_pred_mv,
                                                    y_true_labels, y_pred_mv_labels)
@@ -208,17 +221,17 @@ def metrics_df_from_toml_path(toml_path,
                 records[f'{metric_name}_majority_vote'].append(metric_val)
 
             # ---- min segment dur transform
-            y_pred_np_mindur, _ = lbl_tb_funcs.remove_short_segments(y_pred_np,
-                                                                     segment_inds_list,
-                                                                     timebin_dur=timebin_dur,
-                                                                     min_segment_dur=min_segment_dur,
-                                                                     unlabeled_label=labelmap['unlabeled'])
+            y_pred_np_mindur, _ = remove_short_segments(y_pred_np,
+                                                        segment_inds_list,
+                                                        timebin_dur=timebin_dur,
+                                                        min_segment_dur=min_segment_dur,
+                                                        unlabeled_label=labelmap['unlabeled'])
             y_pred_mindur = to_long_tensor(y_pred_np_mindur).to(device)
-            y_pred_mindur_labels, _, _ = lbl_tb_funcs.lbl_tb2segments(y_pred_np_mindur,
-                                                                      labelmap=labelmap,
-                                                                      t=t,
-                                                                      min_segment_dur=None,
-                                                                      majority_vote=False)
+            y_pred_mindur_labels, _, _ = lbl_tb2segments(y_pred_np_mindur,
+                                                         labelmap=labelmap,
+                                                         t=t,
+                                                         min_segment_dur=None,
+                                                         majority_vote=False)
             y_pred_mindur_labels = ''.join(y_pred_mindur_labels.tolist())
             metric_vals_batch_mindur = compute_metrics(metrics, y_true, y_pred_mindur,
                                                        y_true_labels, y_pred_mindur_labels)
@@ -226,25 +239,55 @@ def metrics_df_from_toml_path(toml_path,
                 records[f'{metric_name}_min_segment_dur'].append(metric_val)
 
             # ---- and finally both transforms, in same order we apply for prediction
-            y_pred_np_mindur_mv, segment_inds_list = lbl_tb_funcs.remove_short_segments(y_pred_np,
-                                                                                        segment_inds_list,
-                                                                                        timebin_dur=timebin_dur,
-                                                                                        min_segment_dur=min_segment_dur,
-                                                                                        unlabeled_label=labelmap[
-                                                                                            'unlabeled'])
-            y_pred_np_mindur_mv = lbl_tb_funcs.majority_vote_transform(y_pred_np_mindur_mv,
+            y_pred_np_mindur_mv, segment_inds_list = remove_short_segments(y_pred_np,
+                                                                           segment_inds_list,
+                                                                           timebin_dur=timebin_dur,
+                                                                           min_segment_dur=min_segment_dur,
+                                                                           unlabeled_label=labelmap[
+                                                                               'unlabeled'])
+            y_pred_np_mindur_mv = majority_vote_transform(y_pred_np_mindur_mv,
                                                                      segment_inds_list)
             y_pred_mindur_mv = to_long_tensor(y_pred_np_mindur_mv).to(device)
-            y_pred_mindur_mv_labels, _, _ = lbl_tb_funcs.lbl_tb2segments(y_pred_np_mindur_mv,
-                                                                         labelmap=labelmap,
-                                                                         t=t,
-                                                                         min_segment_dur=None,
-                                                                         majority_vote=False)
+            y_pred_mindur_mv_labels, _, _ = lbl_tb2segments(y_pred_np_mindur_mv,
+                                                            labelmap=labelmap,
+                                                            t=t,
+                                                            min_segment_dur=None,
+                                                            majority_vote=False)
             y_pred_mindur_mv_labels = ''.join(y_pred_mindur_mv_labels.tolist())
             metric_vals_batch_mindur_mv = compute_metrics(metrics, y_true, y_pred_mindur_mv,
                                                           y_true_labels, y_pred_mindur_mv_labels)
             for metric_name, metric_val in metric_vals_batch_mindur_mv.items():
                 records[f'{metric_name}_min_dur_maj_vote'].append(metric_val)
+
+            # here we measure the number of times a frame error occurs involving 'unlabeled' timebins
+            # within some fixed number of timebins from an onset or offset.
+            # the idea being that if those specific frame errors account
+            # for a large number of all frame errors,
+            # then most frame errors are due to noisiness of segmentation
+            for y_pred_np_vec, y_pred_np_vec_label in zip(
+                    (y_pred_np, y_pred_np_mindur, y_pred_np_mv, y_pred_np_mindur_mv),
+                    ('y_pred_np', 'y_pred_np_mindur', 'y_pred_np_mv', 'y_pred_np_mindur_mv')
+            ):
+                frame_err_vec = y_true_np != y_pred_np_vec
+                n_frame_err = int(frame_err_vec.sum().item())
+                records[f'{y_pred_np_vec_label}_n_frame_err'].append(n_frame_err)
+                unlabeled_err = np.logical_and(
+                    frame_err_vec,
+                    np.logical_or(y_true_np == labelmap['unlabeled'], y_pred_np_vec == labelmap['unlabeled'])
+                )
+                records[f'{y_pred_np_vec_label}_n_unlabeled_frame_err'].append(
+                    int(unlabeled_err.sum().item())
+                )
+                t_unlabeled_err = t[unlabeled_err]
+                t_unlabeled_err_from_onset_offset = [
+                    min(np.abs(np.concatenate((onsets_s, offsets_s)) - a_time))
+                    for a_time in t_unlabeled_err
+                ]
+                counts, _ = np.histogram(t_unlabeled_err_from_onset_offset, bins=np.arange(0.0, 1.0, timebin_dur))
+                n_unlabeled_err_within_n_timebin = counts[:n_timebin_from_onoffset].sum()
+                records[
+                    f'{y_pred_np_vec_label}_n_unlabeled_err_within_{n_timebin_from_onoffset}_timebin_onoffset'
+                ].append(n_unlabeled_err_within_n_timebin)
 
         df = pd.DataFrame.from_records(records)
         return df
@@ -257,6 +300,9 @@ BIRD_ID_MIN_SEGMENT_DUR_MAP = {
     'gy6or6': 0.01,
     'or60yw70': 0.02,
 }
+# number of timebins from an onset or offset
+# in which we count
+N_TIMEBINS_FROM_ONOFFSET = 2
 
 
 def main():
@@ -267,7 +313,9 @@ def main():
         all_dfs = []
         for eval_toml_path in eval_toml_paths:
             print(f'computing metrics from dataset in .toml file: {eval_toml_path.name}')
-            toml_df = metrics_df_from_toml_path(eval_toml_path, min_segment_dur)
+            toml_df = metrics_df_from_toml_path(eval_toml_path,
+                                                min_segment_dur,
+                                                n_timebin_from_onoffset=N_TIMEBINS_FROM_ONOFFSET)
             date = eval_toml_path.parents[0].name  # directory name is date
             print(f'date for this .toml file: {date}')
             toml_df['date'] = date

--- a/src/scripts/Canaries/eval_without_and_with_output_transforms.py
+++ b/src/scripts/Canaries/eval_without_and_with_output_transforms.py
@@ -1,24 +1,21 @@
 # This script is identical to the on for BFSongRepository but with canaries
-from argparse import ArgumentParser
 from collections import defaultdict
 import json
 from pathlib import Path
 
-import joblib
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import torch
 from tqdm import tqdm
-import scipy.io as cpio
 
 import vak.device
 import vak.files
-#import vak.labeled_timebins as labelfuncs
-from vak.labeled_timebins import lbl_tb2segments, majority_vote_transform, lbl_tb_segment_inds_list, remove_short_segments
+from vak.labeled_timebins import lbl_tb2segments, majority_vote_transform, lbl_tb_segment_inds_list, \
+    remove_short_segments
 from vak import config, io, models, transforms
 from vak.datasets.vocal_dataset import VocalDataset
-# In this script we also calculate the distribution of error distance from syllable edges
-import matplotlib.pyplot as plt
+
 
 def compute_metrics(metrics, y_true, y_pred, y_true_labels, y_pred_labels):
     """helper function to compute metrics
@@ -53,18 +50,22 @@ def compute_metrics(metrics, y_true, y_pred, y_true_labels, y_pred_labels):
 
     return metric_vals
 
-Alphanumeric = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+
+ALPHANUMERIC = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+
 
 def remap(labelmap):
     """map integer labels to alphanumeric characters so we can compute edit distance metrics.
     The mapping can be arbitrary as long as it is constant across all times we compute the metric.
     """
-    return {Alphanumeric[ind]: val for ind, (key, val) in enumerate(labelmap.items())}
+    return {ALPHANUMERIC[ind]: val for ind, (key, val) in enumerate(labelmap.items())}
+
 
 def map_number_labels_to_alphanumeric(labelvec):
     """Take a vector of 'str' labels that are all numbers and replace them with a string of characters 
     """
-    return ''.join([Alphanumeric[int(x)] for x in labelvec])
+    return ''.join([ALPHANUMERIC[int(x)] for x in labelvec])
+
 
 def metrics_df_from_toml_path(toml_path,
                               min_segment_dur,
@@ -90,7 +91,7 @@ def metrics_df_from_toml_path(toml_path,
 
     toml_path = Path(toml_path)
     cfg = config.parse.from_toml(toml_path)
-    #spect_standardizer = joblib.load(cfg.eval.spect_scaler_path)
+    # spect_standardizer = joblib.load(cfg.eval.spect_scaler_path)
     with cfg.eval.labelmap_path.open('r') as f:
         labelmap = json.load(f)
 
@@ -107,12 +108,12 @@ def metrics_df_from_toml_path(toml_path,
                                              )
 
     eval_dataset = VocalDataset.from_csv(csv_path=cfg.eval.csv_path,
-                                        split='test',
-                                        labelmap=labelmap,
-                                        spect_key=spect_key,
-                                        timebins_key=timebins_key,
-                                        item_transform=item_transform,
-                                        )
+                                         split='test',
+                                         labelmap=labelmap,
+                                         spect_key=spect_key,
+                                         timebins_key=timebins_key,
+                                         item_transform=item_transform,
+                                         )
 
     eval_data = torch.utils.data.DataLoader(dataset=eval_dataset,
                                             shuffle=False,
@@ -150,9 +151,9 @@ def metrics_df_from_toml_path(toml_path,
         pred_dict = model.predict(pred_data=eval_data,
                                   device=device)
 
-        error_position_distribution = [] # will accumulate error time differences from syllable edges
-        num_err_bin = [] # will accumulate total number of error frames for normalization 
-        
+        error_position_distribution = []  # will accumulate error time differences from syllable edges
+        num_err_bin = []  # will accumulate total number of error frames for normalization 
+
         progress_bar = tqdm(eval_data)
         for ind, batch in enumerate(progress_bar):
             y_true, padding_mask, spect_path = batch['annot'], batch['padding_mask'], batch['spect_path']
@@ -163,20 +164,20 @@ def metrics_df_from_toml_path(toml_path,
             y_true_np = np.squeeze(y_true.cpu().numpy())
             t_vec = vak.files.spect.load(spect_path[0])['t']
             y_true_labels, t_ons_s, t_offs_s = lbl_tb2segments(y_true_np,
-                                                             labelmap,
-                                                             t_vec)
+                                                               labelmap,
+                                                               t_vec)
             y_true_labels = map_number_labels_to_alphanumeric(y_true_labels)
-            y_pred_ind = spect_path[0] #pred_dict['y'].index(spect_path)
-            y_pred = pred_dict[y_pred_ind] #pred_dict['y_pred'][y_pred_ind]
+            y_pred_ind = spect_path[0]  # pred_dict['y'].index(spect_path)
+            y_pred = pred_dict[y_pred_ind]  # pred_dict['y_pred'][y_pred_ind]
             y_pred = torch.argmax(y_pred, dim=1)  # assumes class dimension is 1
             y_pred = torch.flatten(y_pred)
             y_pred = y_pred.unsqueeze(0)[padding_mask]
             y_pred_np = np.squeeze(y_pred.cpu().numpy())
             y_pred_labels, _, _ = lbl_tb2segments(y_pred_np,
-                                                             labelmap,
-                                                             t_vec,
-                                                             min_segment_dur=None,
-                                                             majority_vote=False)
+                                                  labelmap,
+                                                  t_vec,
+                                                  min_segment_dur=None,
+                                                  majority_vote=False)
             y_pred_labels = map_number_labels_to_alphanumeric(y_pred_labels)
 
             metric_vals_batch = compute_metrics(metrics, y_true, y_pred, y_true_labels, y_pred_labels)
@@ -186,16 +187,16 @@ def metrics_df_from_toml_path(toml_path,
             # --- apply majority vote and min segment dur transforms separately
             # need segment_inds_list for both transforms
             segment_inds_list = lbl_tb_segment_inds_list(y_pred_np,
-                                                                    unlabeled_label=labelmap['unlabeled'])
+                                                         unlabeled_label=labelmap['unlabeled'])
 
             # ---- majority vote transform
             y_pred_np_mv = majority_vote_transform(y_pred_np, segment_inds_list)
             y_pred_mv = to_long_tensor(y_pred_np_mv).to(device)
             y_pred_mv_labels, _, _ = lbl_tb2segments(y_pred_np_mv,
-                                                                labelmap,
-                                                                t_vec,
-                                                                min_segment_dur=None,
-                                                                majority_vote=False)
+                                                     labelmap,
+                                                     t_vec,
+                                                     min_segment_dur=None,
+                                                     majority_vote=False)
             y_pred_mv_labels = map_number_labels_to_alphanumeric(y_pred_mv_labels)
 
             metric_vals_batch_mv = compute_metrics(metrics, y_true, y_pred_mv,
@@ -205,18 +206,18 @@ def metrics_df_from_toml_path(toml_path,
 
             # ---- min segment dur transform
             y_pred_np_mindur, _ = remove_short_segments(y_pred_np,
-                                                                   segment_inds_list,
-                                                                   timebin_dur=timebin_dur,
-                                                                   min_segment_dur=min_segment_dur,
-                                                                   unlabeled_label=labelmap['unlabeled'])
+                                                        segment_inds_list,
+                                                        timebin_dur=timebin_dur,
+                                                        min_segment_dur=min_segment_dur,
+                                                        unlabeled_label=labelmap['unlabeled'])
             y_pred_mindur = to_long_tensor(y_pred_np_mindur).to(device)
             y_pred_mindur_labels, _, _ = lbl_tb2segments(y_pred_np_mindur,
-                                                                    labelmap,
-                                                                    t_vec,
-                                                                    min_segment_dur=None,
-                                                                    majority_vote=False)
+                                                         labelmap,
+                                                         t_vec,
+                                                         min_segment_dur=None,
+                                                         majority_vote=False)
             y_pred_mindur_labels = map_number_labels_to_alphanumeric(y_pred_mindur_labels)
-    
+
             metric_vals_batch_mindur = compute_metrics(metrics, y_true, y_pred_mindur,
                                                        y_true_labels, y_pred_mindur_labels)
             for metric_name, metric_val in metric_vals_batch_mindur.items():
@@ -224,44 +225,45 @@ def metrics_df_from_toml_path(toml_path,
 
             # ---- and finally both transforms, in same order we apply for prediction
             y_pred_np_mindur_mv, segment_inds_list = remove_short_segments(y_pred_np,
-                                                                                      segment_inds_list,
-                                                                                      timebin_dur=timebin_dur,
-                                                                                      min_segment_dur=min_segment_dur,
-                                                                                      unlabeled_label=labelmap[
-                                                                                          'unlabeled'])
+                                                                           segment_inds_list,
+                                                                           timebin_dur=timebin_dur,
+                                                                           min_segment_dur=min_segment_dur,
+                                                                           unlabeled_label=labelmap[
+                                                                               'unlabeled'])
             y_pred_np_mindur_mv = majority_vote_transform(y_pred_np_mindur_mv,
-                                                                     segment_inds_list)
+                                                          segment_inds_list)
             y_pred_mindur_mv = to_long_tensor(y_pred_np_mindur_mv).to(device)
             y_pred_mindur_mv_labels, _, _ = lbl_tb2segments(y_pred_np_mindur_mv,
-                                                                       labelmap,
-                                                                       t_vec,
-                                                                       min_segment_dur=None,
-                                                                       majority_vote=False)
-            
-            
+                                                            labelmap,
+                                                            t_vec,
+                                                            min_segment_dur=None,
+                                                            majority_vote=False)
+
             y_pred_mindur_mv_labels = map_number_labels_to_alphanumeric(y_pred_mindur_mv_labels)
-        
+
             metric_vals_batch_mindur_mv = compute_metrics(metrics, y_true, y_pred_mindur_mv,
                                                           y_true_labels, y_pred_mindur_mv_labels)
             for metric_name, metric_val in metric_vals_batch_mindur_mv.items():
                 records[f'{metric_name}_min_dur_maj_vote'].append(metric_val)
 
             # ---- accumulate error distances from true segment edges
-            num_err_bin.append(sum(y_true_np-y_pred_np_mindur_mv != 0))
-            err = (y_true_np-y_pred_np_mindur_mv != 0) & ((y_true_np == 0) | (y_pred_np_mindur_mv==0))
-            error_position_distribution.append([min(np.abs(np.concatenate((t_ons_s,t_offs_s))-tm)) for tm in t_vec[err==True]])
-        
+            num_err_bin.append(sum(y_true_np - y_pred_np_mindur_mv != 0))
+            err = (y_true_np - y_pred_np_mindur_mv != 0) & ((y_true_np == 0) | (y_pred_np_mindur_mv == 0))
+            error_position_distribution.append(
+                [min(np.abs(np.concatenate((t_ons_s, t_offs_s)) - tm)) for tm in t_vec[err == True]])
+
         error_position_distribution = np.concatenate(error_position_distribution)
 
         df = pd.DataFrame.from_records(records)
         t1 = t_vec[1]
-        return df,error_position_distribution,num_err_bin,t1
+        return df, error_position_distribution, num_err_bin, t1
 
 
 CONFIG_ROOT = Path('src\\configs\\Canaries')
 BIRD_ID_MIN_SEGMENT_DUR_MAP = {'llb3': 0.005,
-    'llb11': 0.005,
-    'llb16': 0.005}
+                               'llb11': 0.005,
+                               'llb16': 0.005}
+
 
 def main():
     plt.figure()
@@ -273,11 +275,11 @@ def main():
         all_dfs = []
         for eval_toml_path in eval_toml_paths:
             print(f'computing metrics from dataset in .toml file: {eval_toml_path.name}')
-            toml_df,error_dist,num_err_bin,t1 = metrics_df_from_toml_path(eval_toml_path, min_segment_dur)
+            toml_df, error_dist, num_err_bin, t1 = metrics_df_from_toml_path(eval_toml_path, min_segment_dur)
             all_dfs.append(toml_df)
-            bins = np.histogram(error_dist,bins = np.arange(0.0,1.0,t1))
+            bins = np.histogram(error_dist, bins=np.arange(0.0, 1.0, t1))
             plt.plot(bins[0])
-            err_stat.append(sum(bins[0][:2])/sum(num_err_bin))
+            err_stat.append(sum(bins[0][:2]) / sum(num_err_bin))
 
         output_df = pd.concat(all_dfs)
         output_df['bird_id'] = bird_id
@@ -287,6 +289,7 @@ def main():
         print(f'saving csv as: {csv_path}')
         output_df.to_csv(csv_path, index=False)
     plt.show()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Main point of pull request was to add computation of the number of unlabeled errors within fixed number of timebins from an onset or offset, as we did for canary song.

Updated notebook to reflect results after re-running.

Also made PEP8 fixes to canary script.