### PR TITLE
add config files for BFSongRepo learning curves

### DIFF
--- a/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_bl26lb16_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_bl26lb16_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdef"
+data_dir = "~/Documents/data/BFSongRepository/bl26lb16/041912/"
+output_dir = "./data/BFSongRepository/learncurve/bl26lb16/"
+spect_output_dir = "./data/BFSongRepository/learncurve/bl26lb16/"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480,]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 50
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/bl26lb16/"
+csv_path = "data/BFSongRepository/learncurve/bl26lb16/041912_prep_210423_094142.csv"
+
+[DATALOADER]
+window_size = 88
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_gr41rd51_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_gr41rd51_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdefgjkm"
+data_dir = "~/Documents/data/BFSongRepository/gr41rd51/062112/has_notmat"
+output_dir = "./data/BFSongRepository/learncurve/gr41rd51"
+spect_output_dir = "./data/BFSongRepository/learncurve/gr41rd51"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480,]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 50
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/gr41rd51"
+csv_path = "data/BFSongRepository/learncurve/gr41rd51/has_notmat_prep_210423_100311.csv"
+
+[DATALOADER]
+window_size = 88
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_gy6or6_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_gy6or6_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdefghjk"
+data_dir = "~/Documents/data/BFSongRepository/gy6or6/032212"
+output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+spect_output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480,]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 50
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/gy6or6/"
+csv_path = "data/BFSongRepository/learncurve/gy6or6/032212_prep_210423_094825.csv"
+
+[DATALOADER]
+window_size = 88
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_or60yw70_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/submitted_params/config_BFSongRepository_or60yw70_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdefg"
+data_dir = "~/Documents/data/BFSongRepository/or60yw70/0927_092812"
+output_dir = "./data/BFSongRepository/learncurve/or60yw70"
+spect_output_dir = "./data/BFSongRepository/learncurve/or60yw70"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480,]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 50
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/or60yw70"
+csv_path = "data/BFSongRepository/learncurve/or60yw70/0927_092812_prep_210423_095512.csv"
+
+[DATALOADER]
+window_size = 88
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_bl26lb16_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_bl26lb16_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdef"
+data_dir = "~/Documents/data/BFSongRepository/bl26lb16/041912/"
+output_dir = "./data/BFSongRepository/learncurve/bl26lb16/"
+spect_output_dir = "./data/BFSongRepository/learncurve/bl26lb16/"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480, 600]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 400
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/bl26lb16/"
+csv_path = "data/BFSongRepository/learncurve/bl26lb16/041912_prep_210423_094142.csv"
+
+[DATALOADER]
+window_size = 176
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_gr41rd51_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_gr41rd51_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdefgjkm"
+data_dir = "~/Documents/data/BFSongRepository/gr41rd51/062112/has_notmat_gaps_cleaned"
+output_dir = "./data/BFSongRepository/learncurve/gr41rd51"
+spect_output_dir = "./data/BFSongRepository/learncurve/gr41rd51"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480, 600]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 400
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/gr41rd51"
+csv_path = "data/BFSongRepository/learncurve/gr41rd51/has_notmat_prep_210423_100311.csv"
+
+[DATALOADER]
+window_size = 176
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_gy6or6_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_gy6or6_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdefghjk"
+data_dir = "~/Documents/data/BFSongRepository/gy6or6/032212"
+output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+spect_output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480, 600]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 400
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/gy6or6/"
+csv_path = "data/BFSongRepository/learncurve/gy6or6/032212_prep_210423_094825.csv"
+
+[DATALOADER]
+window_size = 176
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_or60yw70_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/window_size_176_ckpt_400/config_BFSongRepository_or60yw70_learncurve.toml
@@ -1,0 +1,38 @@
+[PREP]
+labelset = "iabcdefg"
+data_dir = "~/Documents/data/BFSongRepository/or60yw70/0927_092812"
+output_dir = "./data/BFSongRepository/learncurve/or60yw70"
+spect_output_dir = "./data/BFSongRepository/learncurve/or60yw70"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480, 600]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 400
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/or60yw70"
+csv_path = "data/BFSongRepository/learncurve/or60yw70/0927_092812_prep_210423_095512.csv"
+
+[DATALOADER]
+window_size = 176
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/window_size_352_ckpt_400/config_BFSongRepository_gy6or6_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/window_size_352_ckpt_400/config_BFSongRepository_gy6or6_learncurve.toml
@@ -1,0 +1,39 @@
+[PREP]
+labelset = "iabcdefghjk"
+data_dir = "~/Documents/data/BFSongRepository/gy6or6/032212"
+output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+spect_output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480,]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 400
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/gy6or6/"
+csv_path = "data/BFSongRepository/learncurve/gy6or6/032212_prep_210423_094825.csv"
+previous_run_path = "results/BFSongRepository/learncurve/gy6or6/results_210425_202400/"
+
+[DATALOADER]
+window_size = 352
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256

--- a/src/configs/BFSongRepository/learncurve/window_size_88_ckpt_400/config_BFSongRepository_gy6or6_learncurve.toml
+++ b/src/configs/BFSongRepository/learncurve/window_size_88_ckpt_400/config_BFSongRepository_gy6or6_learncurve.toml
@@ -1,0 +1,39 @@
+[PREP]
+labelset = "iabcdefghjk"
+data_dir = "~/Documents/data/BFSongRepository/gy6or6/032212"
+output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+spect_output_dir = "./data/BFSongRepository/learncurve/gy6or6/"
+audio_format = "cbin"
+annot_format = "notmat"
+test_dur = 400
+train_dur = 900
+val_dur = 80
+
+[SPECT_PARAMS]
+fft_size = 512
+step_size = 64
+
+[LEARNCURVE]
+models = "TweetyNet"
+train_set_durs = [ 30, 45, 75, 120, 180, 480,]
+num_replicates = 10
+normalize_spectrograms = "Yes"
+batch_size = 8
+num_epochs = 50
+val_step = 400
+ckpt_step = 200
+patience = 4
+num_workers = 4
+device = "cuda"
+root_results_dir = "./results/BFSongRepository/learncurve/gy6or6/"
+csv_path = "data/BFSongRepository/learncurve/gy6or6/032212_prep_210423_094825.csv"
+previous_run_path = "results/BFSongRepository/learncurve/gy6or6/results_210425_202400/"
+
+[DATALOADER]
+window_size = 88
+
+[TweetyNet.optimizer]
+lr = 0.001
+
+[TweetyNet.network]
+hidden_size = 256


### PR DESCRIPTION
- add src/configs/BFSongRepository/learncurve with config files
  - including configs for learning curves run with submitted_params
  - and configs that vary window size + checkpoint step

running these configs is when I realized that we were stopping **too** early.
Not adding results source data .csv files yet, because we will need to run same experiments on the birds we end up using from BirdsongRecognition.