### PR TITLE
BUG: remove 'padding' from kwargs to fix #166

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install libsndfile1 on ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libsndfile1
+      - uses: excitedleigh/setup-nox@v2.0.0
+      - name: tests
+        run: nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,30 @@
+import sys
+
+import nox
+
+
+IS_MACOS = sys.platform == "darwin"
+
+
+@nox.session
+@nox.parametrize("torch",
+                 [
+                     "1.7.1",
+                     "1.8.0",
+                     "1.8.1",
+                     "1.9.0",
+                     "1.10.0",
+                 ]
+                 )
+def tests(session, torch):
+    torch_string = f"torch=={torch}"
+    if not IS_MACOS:
+        torch_string += "+cpu"
+        torch_string = [torch_string, '-f', 'https://download.pytorch.org/whl/torch_stable.html']
+    else:
+        torch_string = [torch_string]  # wrap in list so we can unpack with * even if only one item
+    session.install(*torch_string)
+    session.install("vak>=0.4.0b5")
+    session.install(".")
+    session.install("pytest")
+    session.run("pytest")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ test = [
     "pytest-cov",
 ]
 dev = [
-    "ipython>=7.30.1"
+    "ipython>=7.30.1",
+    "nox",
 ]
 
 [project.urls]

--- a/src/tweetynet/network.py
+++ b/src/tweetynet/network.py
@@ -18,7 +18,10 @@ class Conv2dTF(nn.Conv2d):
     used to maintain behavior of original implementation of TweetyNet that used Tensorflow 1.0 low-level API
     """
     def __init__(self, *args, **kwargs):
-        super(Conv2dTF, self).__init__(*args, **kwargs)
+        # remove 'padding' from ``kwargs`` to avoid bug in ``torch`` => 1.7.2
+        # see https://github.com/yardencsGitHub/tweetynet/issues/166
+        kwargs_super = {k: v for k, v in kwargs.items() if k != 'padding'}
+        super(Conv2dTF, self).__init__(*args, **kwargs_super)
         padding = kwargs.get("padding", "SAME")
         if not isinstance(padding, str):
             raise TypeError(f"value for 'padding' argument should be a string, one of: {self.PADDING_METHODS}")

--- a/tests/test_tweetynet.py
+++ b/tests/test_tweetynet.py
@@ -1,54 +1,46 @@
-import unittest
-
 import torch
+import pytest
 
 import tweetynet
 
 
-class TestConv2dTF(unittest.TestCase):
-    def test_Conv2dTF_same_padding(self):
-        input_size = (1, 513, 88)
-        batch_size = tuple((10,) + input_size[:])
-        batch_of_spects = torch.rand(batch_size)
-        n_filters = 64
-        kernel_size = (5, 5)
+@pytest.mark.parametrize(
+    'padding',
+    [
+        'SAME',
+        'same'
+    ]
+)
+def test_Conv2dTF_same_padding(padding):
+    input_size = (1, 513, 88)
+    batch_size = tuple((10,) + input_size[:])
+    batch_of_spects = torch.rand(batch_size)
+    n_filters = 64
+    kernel_size = (5, 5)
 
-        conv2dtf = tweetynet.network.Conv2dTF(in_channels=input_size[0],
-                                              out_channels=n_filters,
-                                              kernel_size=kernel_size,
-                                              padding="SAME")
+    conv2dtf = tweetynet.network.Conv2dTF(in_channels=input_size[0],
+                                          out_channels=n_filters,
+                                          kernel_size=kernel_size,
+                                          padding=padding)
 
-        out = conv2dtf(batch_of_spects)
-        assert tuple(out.shape)[2:] == batch_size[2:]
+    out = conv2dtf(batch_of_spects)
+    assert tuple(out.shape)[2:] == batch_size[2:]
 
 
-class TestHiddenSize(unittest.TestCase):
-    def test_default(self):
-        NUM_CLASSES = 11
+@pytest.mark.parametrize(
+    'hidden_size',
+    [
+        None,
+        2048
+    ]
+)
+def test_hidden_size(hidden_size):
+    NUM_CLASSES = 11
 
-        net = tweetynet.network.TweetyNet(num_classes=NUM_CLASSES)
+    net = tweetynet.network.TweetyNet(num_classes=NUM_CLASSES,
+                                      hidden_size=hidden_size)
 
-        self.assertTrue(
-            net.rnn.input_size == net.rnn_input_size
-        )
+    assert net.rnn.input_size == net.rnn_input_size
+    if hidden_size is not None:
+        assert net.rnn.hidden_size == net.hidden_size == hidden_size
 
-        # test that we default to hidden size equal to input size
-        self.assertTrue(
-            net.rnn.hidden_size == net.rnn_input_size
-        )
-
-    def test_not_default(self):
-        NUM_CLASSES = 11
-        HIDDEN_SIZE = 2048
-
-        net = tweetynet.network.TweetyNet(num_classes=NUM_CLASSES,
-                                          hidden_size=HIDDEN_SIZE)
-
-        self.assertTrue(
-            net.rnn.input_size == net.rnn_input_size
-        )
-
-        # test that we default to hidden size equal to input size
-        self.assertTrue(
-            net.rnn.hidden_size == net.hidden_size == HIDDEN_SIZE
-        )


### PR DESCRIPTION
removes `'padding'` argument of `Conv2d` from `kwargs` *only* when calling `super` as described in #166 

This also fixes https://github.com/NickleDave/vak/issues/370