### PR TITLE
Fix link to gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 [![PyPI version](https://badge.fury.io/py/tweetynet.svg)](https://badge.fury.io/py/tweetynet)
 
 # TweetyNet
-<p align="center"><a href="https://drive.google.com/uc?export=view&id=1X3u6BIXuFuFlhhm_cakB_hcLEI2ecLjk"><img src="https://drive.google.com/uc?export=view&id=1X3u6BIXuFuFlhhm_cakB_hcLEI2ecLjk" style="width: 650px; max-width: 100%; height: auto" title="Click to enlarge picture" /></p>
-
-
+<p align="center"><img src="https://media2.giphy.com/media/R3LFaSZD9168tLD83v/giphy.gif?cid=790b76115c4c17f56cbae7abeff7b8602e2b095446c9dbfe&rid=giphy.gif&ct=g"></p>
 
 Now published in eLife: https://elifesciences.org/articles/63853  
 Code to reproduce results from the article is in the directory [`./article`](./article)


### PR DESCRIPTION
use link to GIPHY upload instead:
https://media2.giphy.com/media/R3LFaSZD9168tLD83v/giphy.gif?cid=790b76115c4c17f56cbae7abeff7b8602e2b095446c9dbfe&rid=giphy.gif&ct=g