### PR TITLE
CI: Fix ci.yml so we don't get spurious failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -21,6 +21,6 @@ jobs:
       - name: install libsndfile1 on ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install libsndfile1
-      - uses: excitedleigh/setup-nox@v2.0.0
+      - uses: excitedleigh/setup-nox@v2.1.0
       - name: tests
         run: nox


### PR DESCRIPTION
- Use Python 3.8-3.10, not Python 3.7,
  since we just bumped lower bound on Python in #216
- Need to use nox action v.2.1.0, not 2.0.0