### PR TITLE
CLN: Make fixes to work with vak 0.8.0, fixes #218

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.8"
 license = {file = "LICENSE"}
 dependencies = [
     "torch>=1.7.1",
-    "vak>=0.6.0"
+    "vak>=0.8.0"
 ]
 [project.optional-dependencies]
 test = [

--- a/src/tweetynet/model.py
+++ b/src/tweetynet/model.py
@@ -11,7 +11,7 @@ def acc(y_pred, y):
 
 class TweetyNetModel(vak.Model):
     @classmethod
-    def from_config(cls, config):
+    def from_config(cls, config, post_tfm=None):
         network = TweetyNet(**config['network'])
         loss = torch.nn.CrossEntropyLoss(**config['loss'])
         optimizer = torch.optim.Adam(params=network.parameters(), **config['optimizer'])
@@ -19,4 +19,4 @@ class TweetyNetModel(vak.Model):
                    'levenshtein': vak.metrics.Levenshtein(),
                    'segment_error_rate': vak.metrics.SegmentErrorRate(),
                    'loss': torch.nn.CrossEntropyLoss()}
-        return cls(network=network, optimizer=optimizer, loss=loss, metrics=metrics)
+        return cls(network=network, optimizer=optimizer, loss=loss, metrics=metrics, post_tfm=post_tfm)


### PR DESCRIPTION
- Add post_tfm parameter to TweetyNetModel.from_config
- DEV: Raise minimum required version of vak to 0.8.0